### PR TITLE
Refactor pool parameter type in terraform.yml

### DIFF
--- a/azure-pipelines/templates/jobs/terraform.yml
+++ b/azure-pipelines/templates/jobs/terraform.yml
@@ -4,14 +4,13 @@ parameters:
   - name: Environment
     type: string
   - name: pool
-    type: object
-    default:
-      name: Default
+    type: string
+    default: Default
 
 jobs:
   - job: Terraform
     displayName: 'Terraform Infrastructure'
-    pool: ${{ parameters.pool }}
+  pool: ${{ parameters.pool }}
     steps:
       - checkout: self
       - task: TerraformTask@5


### PR DESCRIPTION
Changed the 'pool' parameter from type 'object' to 'string' with a default value of 'Default' in the Terraform pipeline template. Updated job definition to use the new pool parameter type.