### PR TITLE
Add TerraformInstaller task to pipeline

### DIFF
--- a/azure-pipelines/templates/jobs/terraform.yml
+++ b/azure-pipelines/templates/jobs/terraform.yml
@@ -13,6 +13,9 @@ jobs:
     pool: ${{ parameters.pool }}
     steps:
       - checkout: self
+      - task: TerraformInstaller@1
+        inputs:
+          terraformVersion: '1.13.3'
       - task: TerraformTask@5
         displayName: 'Terraform Init'
         inputs:


### PR DESCRIPTION
Introduced the TerraformInstaller@1 task to ensure Terraform version 1.13.3 is installed before running Terraform commands in the pipeline.