### PR TITLE
Rename pipeline variable 'pool' to 'PoolName'

### DIFF
--- a/azure-pipelines/clients/demo/dev-pipeline.yml
+++ b/azure-pipelines/clients/demo/dev-pipeline.yml
@@ -2,7 +2,7 @@ trigger: none
 
 variables:
   - group: tf-shared-vars
-  - name: pool
+  - name: PoolName
     value: Default
 
 stages:


### PR DESCRIPTION
Updated the variable name from 'pool' to 'PoolName' in the dev-pipeline.yml file for consistency or clarity.