### PR TITLE
Add explicit job dependencies to Terraform pipeline

### DIFF
--- a/azure-pipelines/templates/jobs/terraform.yml
+++ b/azure-pipelines/templates/jobs/terraform.yml
@@ -35,11 +35,11 @@ jobs:
       ClientName: ${{ parameters.ClientName }}
       Environment: ${{ parameters.Environment }}
       PoolName: ${{ parameters.PoolName }}
-    dependsOn: Terraform_Validate
+    
 
   - template: ./terraform/terraform-apply.yml
     parameters:
       ClientName: ${{ parameters.ClientName }}
       Environment: ${{ parameters.Environment }}
       PoolName: ${{ parameters.PoolName }}
-    dependsOn: Terraform_Plan
+    

--- a/azure-pipelines/templates/jobs/terraform/terraform-apply.yml
+++ b/azure-pipelines/templates/jobs/terraform/terraform-apply.yml
@@ -8,6 +8,7 @@ parameters:
 
 jobs:
   - job: Terraform_Apply
+    dependsOn: Terraform_Plan
     displayName: "Terraform Apply - ${{ parameters.ClientName }}-${{ parameters.Environment }}"
     pool:
       name: ${{ parameters.PoolName }}

--- a/azure-pipelines/templates/jobs/terraform/terraform-plan.yml
+++ b/azure-pipelines/templates/jobs/terraform/terraform-plan.yml
@@ -8,6 +8,7 @@ parameters:
 
 jobs:
   - job: Terraform_Plan
+    dependsOn: Terraform_Validate
     displayName: "Terraform Plan - ${{ parameters.ClientName }}-${{ parameters.Environment }}"
     pool:
       name: ${{ parameters.PoolName }}

--- a/azure-pipelines/templates/jobs/terraform/terraform-validate.yml
+++ b/azure-pipelines/templates/jobs/terraform/terraform-validate.yml
@@ -8,6 +8,7 @@ parameters:
 
 jobs:
   - job: Terraform_Validate
+    dependsOn: Terraform_Init
     displayName: "Terraform Validate - ${{ parameters.ClientName }}-${{ parameters.Environment }}"
     pool:
       name: ${{ parameters.PoolName }}


### PR DESCRIPTION
Moved 'dependsOn' statements from the main terraform.yml template into the respective job templates for apply, plan, and validate steps. This clarifies job execution order and improves maintainability by making dependencies explicit within each job definition.