### PR TITLE
Configure azurerm backend and remove Redis non-SSL port

### DIFF
--- a/terraform/environments/dev/main.tf
+++ b/terraform/environments/dev/main.tf
@@ -1,3 +1,7 @@
+terraform {
+  backend "azurerm" {}
+}
+
 locals {
   computed_resource_group_name = var.resource_group_name != "" ? var.resource_group_name : "${var.client}-${var.environment}-rg"
 }

--- a/terraform/environments/prod/main.tf
+++ b/terraform/environments/prod/main.tf
@@ -6,6 +6,10 @@ module "network" {
 	resource_group_name = local.computed_resource_group_name
 }
 
+terraform {
+  backend "azurerm" {}
+}
+
 # Outputs for subnet IDs:
 # module.network.aks_subnet_id
 # module.network.postgresql_subnet_id

--- a/terraform/environments/staging/main.tf
+++ b/terraform/environments/staging/main.tf
@@ -1,3 +1,7 @@
+terraform {
+	backend "azurerm" {}
+}
+
 locals {
 	computed_resource_group_name = var.resource_group_name != "" ? var.resource_group_name : "${var.client}-${var.environment}-rg"
 }

--- a/terraform/modules/rediscache/main.tf
+++ b/terraform/modules/rediscache/main.tf
@@ -5,7 +5,6 @@ resource "azurerm_redis_cache" "main" {
   capacity            = var.capacity
   family              = var.family
   sku_name            = var.sku_name
-  enable_non_ssl_port = var.enable_non_ssl_port
 }
 
 resource "azurerm_private_endpoint" "redis" {

--- a/terraform/modules/rediscache/variables.tf
+++ b/terraform/modules/rediscache/variables.tf
@@ -16,7 +16,6 @@ variable "resource_group_name" {
 variable "capacity" { default = 1 }
 variable "family" { default = "C" }
 variable "sku_name" { default = "Basic" }
-variable "enable_non_ssl_port" { default = false }
 
 variable "subnet_id" {
 	description = "Subnet id for Redis"


### PR DESCRIPTION
Added azurerm backend configuration to dev, staging, and prod environment main.tf files for remote state management. Removed the enable_non_ssl_port variable and its usage from the rediscache module to improve security and simplify configuration.